### PR TITLE
Fixed Clang on Windows detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set(ASMTK_PRIVATE_CFLAGS_DBG "")                 # Private compiler flags used b
 set(ASMTK_PRIVATE_CFLAGS_REL "")                 # Private compiler flags used by release builds.
 
 if (NOT ASMTK_NO_CUSTOM_FLAGS)
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "x${CMAKE_CXX_SIMULATE_ID}" STREQUAL "xMSVC")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC" OR "x${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "xMSVC")
     list(APPEND ASMTK_PRIVATE_CFLAGS
       -MP                      # [+] Multi-Process Compilation.
       -GR-                     # [-] Runtime type information.


### PR DESCRIPTION
Compiling asmtk on Windows with Clang produces compile errors:
```
clang++: error: unknown argument: '-Zc:inline'
clang++: error: unknown argument: '-Zc:strictStrings'
clang++: error: unknown argument: '-Zc:threadSafeInit-'
```
They are caused by incorrect detection of MSVC-compatible frontend, CMAKE_CXX_COMPILER_FRONTEND_VARIANT should be used instead of CMAKE_CXX_SIMULATE_ID, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_FRONTEND_VARIANT.html and https://discourse.cmake.org/t/how-to-determine-if-clang-or-clang-cl-is-used-on-windows/4129/5